### PR TITLE
Consistent naming

### DIFF
--- a/content/post/multilingual-series/part-1/index.md
+++ b/content/post/multilingual-series/part-1/index.md
@@ -39,7 +39,7 @@ languages:
 	languageName: Français
 	weight: 2
   es:
-	languageName: Spanish
+	languageName: Español
 	weight: 3
 ```
 
@@ -63,7 +63,7 @@ languages:
 	description: Tous ce que vous avez toujours voulu savoir sur les trois langues.
 	twitter_handle: 3Languages_france
   es:
-	languageName: Spanish
+	languageName: Español
 	weight: 3
 	description: Todo lo que necesitas saber sobre los tres idiomas.
 	twitter_handle: 3Languages_espana
@@ -119,7 +119,7 @@ languages:
 	weight: 2
 	contentDir: content/french
   es:
-	languageName: Spanish
+	languageName: Español
 	weight: 3
 	contentDir: content/spanish
 ```

--- a/content/post/multilingual-series/part-1/index.md
+++ b/content/post/multilingual-series/part-1/index.md
@@ -23,7 +23,7 @@ In this first part, we’ll see how set up your multilingual Hugo project and tr
 
 When undertaking a multilingual project in Hugo, the first thing to do would be to tell Hugo what our supported languages are. For this project, we’ll have three:
 
-1. English 🇬🇧
+1. English 🇺🇸
 2. French 🇫🇷
 3. Spanish 🇪🇸
 
@@ -321,7 +321,7 @@ By default, Hugo will store your default language pages at the root of your `pub
 
 So quiet logically our About pages would en up at:
 
-- `about/index.html` 🇬🇧
+- `about/index.html` 🇺🇸
 - `fr/about/index.html` 🇫🇷
 - `es/about/index.html` 🇪🇸
 


### PR DESCRIPTION
Thank you for this blog post! I'm new to Hugo and fell upon it while researching I18n solutions. 

While flag icons generally should not be used for depicting language, use US flag icon if using American-English rather than British-English

Also, use Español instead of Spanish for consistency. I support the PR request made here as well with important indentation fixes https://github.com/regisphilibert/rp_hugo/pull/6


